### PR TITLE
add auto gpu init switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please make sure that you have installed Nvidia driver for you GPU. You could ve
 1. Build the miner by running `curl -L https://github.com/alephium/gpu-miner/raw/master/get-miner.sh | bash`
 2. Run `gpu-miner/run-miner.sh` to start the miner
 
-You could specify the miner api with `-a broker` parameters, GPU indexes with `-g 1 2` and enable the alternate GPU init with '-o'. The alternate GPU init might improve performance for some cards.
+You could specify the miner api with `-a broker` parameters, GPU indexes with `-g 1 2`.
 
 ### Windows miner from source code
 

--- a/src/blake3.cu
+++ b/src/blake3.cu
@@ -548,13 +548,12 @@ void config_cuda(int device_id, int *grid_size, int *block_size)
     cudaDeviceProp props;
     cudaGetDeviceProperties(&props, device_id);
     
-    
     // If using a 2xxx or 3xxx card, use the new grid calc
-    bool use_rtx_grid_bloc = ((major << 4) + minor) >= 0x75;
+    bool use_rtx_grid_bloc = ((props.major << 4) + props.minor) >= 0x75;
     
     // If compiling for windows, override the test and force the new calc
 #ifdef _WIN32
-	use_rtx_grid_bloc = true;
+    use_rtx_grid_bloc = true;
 #endif
     
     int cores_size = get_device_cores(device_id);

--- a/src/blake3.cu
+++ b/src/blake3.cu
@@ -540,15 +540,25 @@ int get_device_cores(int device_id)
     return cores_size;
 }
 
-void config_cuda(int device_id, int *grid_size, int *block_size, int new_grid_calc)
+void config_cuda(int device_id, int *grid_size, int *block_size)
 {
     cudaSetDevice(device_id);
     cudaOccupancyMaxPotentialBlockSize(grid_size, block_size, blake3_hasher_mine);
-
+    
+    cudaDeviceProp props;
+    cudaGetDeviceProperties(&props, device_id);
+    
+    
+    // If using a 2xxx or 3xxx card, use the new grid calc
+    bool use_rtx_grid_bloc = ((major << 4) + minor) >= 0x75;
+    
+    // If compiling for windows, override the test and force the new calc
+#ifdef _WIN32
+	use_rtx_grid_bloc = true;
+#endif
+    
     int cores_size = get_device_cores(device_id);
-    if (new_grid_calc) {
-        cudaDeviceProp props;
-        cudaGetDeviceProperties(&props, device_id);
+    if (use_rtx_grid_bloc) {
         *grid_size = props.multiProcessorCount * 2;
         *block_size = cores_size / *grid_size * 4;
     } else {

--- a/src/main.cu
+++ b/src/main.cu
@@ -336,7 +336,6 @@ int main(int argc, char **argv)
     char broker_ip[16];
     strcpy(broker_ip, "127.0.0.1");
 
-    bool new_grid_calc = true;
     int command;
     while ((command = getopt(argc, argv, "g:a:o")) != -1)
     {
@@ -370,16 +369,13 @@ int main(int argc, char **argv)
                 use_device[device] = true;
             }
             break;
-        case 'o':
-            new_grid_calc = false;
-            break;
         default:
             printf("Invalid command %c\n", command);
             exit(1);
         }
     }
 
-    mining_workers_init(gpu_count, new_grid_calc);
+    mining_workers_init(gpu_count);
     setup_gpu_worker_count(gpu_count, gpu_count * parallel_mining_works_per_gpu);
 
     loop = uv_default_loop();

--- a/src/worker.h
+++ b/src/worker.h
@@ -34,7 +34,7 @@ typedef struct mining_worker_t {
     uv_timer_t timer;
 } mining_worker_t;
 
-void mining_worker_init(mining_worker_t *self, uint32_t id, int device_id, int new_grid_calc)
+void mining_worker_init(mining_worker_t *self, uint32_t id, int device_id)
 {
     self->id = id;
 
@@ -121,11 +121,11 @@ void store_req_data(ssize_t worker_id, mining_worker_t *worker)
     atomic_store(&(mining_req->worker), worker);
 }
 
-void mining_workers_init(int gpu_count, int new_grid_calc)
+void mining_workers_init(int gpu_count)
 {
     for (size_t i = 0; i < gpu_count * parallel_mining_works_per_gpu; i++) {
         mining_worker_t *worker = mining_workers + i;
-        mining_worker_init(worker, (uint32_t)i, i % gpu_count, new_grid_calc);
+        mining_worker_init(worker, (uint32_t)i, i % gpu_count);
         store_req_data(i, worker);
     }
 }

--- a/src/worker.h
+++ b/src/worker.h
@@ -41,7 +41,7 @@ void mining_worker_init(mining_worker_t *self, uint32_t id, int device_id)
     self->device_id = device_id;
     cudaSetDevice(device_id);
     TRY( cudaStreamCreate(&(self->stream)) );
-    config_cuda(device_id, &self->grid_size, &self->block_size, new_grid_calc);
+    config_cuda(device_id, &self->grid_size, &self->block_size);
     printf("Worker %d: device id %d, grid size %d, block size %d\n", self->id, self->device_id, self->grid_size, self->block_size);
 
     TRY( cudaMallocHost(&(self->hasher), sizeof(blake3_hasher)) );


### PR DESCRIPTION
Remove the flag to override, and switch gpu init based on the actual GPU generations for best performances.

Tested on a mixed gen rig, 3xxx perfs stayed the same, 1xxx went back up by ~30%
