### PR TITLE
Publish to dockerhub when a tag is pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,6 @@ jobs:
           build-args: RELEASE=${{ steps.get_version.outputs.VERSION-NO-V }}
           platforms: linux/amd64
           tags: |
-            docker.io/capito27/gpu-miner:${{ steps.get_version.outputs.VERSION }}
-            docker.io/capito27/gpu-miner:latest
+            docker.io/alephium/gpu-miner:${{ steps.get_version.outputs.VERSION }}
+            docker.io/alephium/gpu-miner:latest
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
   build-windows-artifact:
     name: build-windows-artifact
     runs-on: windows-latest
-    needs: build-linux-artifact
     steps:
       - uses: actions/checkout@v2
         with:
@@ -77,16 +76,27 @@ jobs:
         with:
           name: windows-binary
           path: bin/gpu-miner_*.exe
-
-      - name: Get linux artifact (Release prep)
-        if: startsWith(github.ref, 'refs/tags/')
+  
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    # If both artifacts were built properly and this is a tag
+    if: ${{ needs.build-linux-artifact.result == 'success' && needs.build-linux-artifact.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
+    needs: [build-linux-artifact, build-windows-artifact]
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Get linux artifact
         uses: actions/download-artifact@v2
         with:
           name: linux-binary
-          path: bin/
+              
+      - name: Get Windows artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-binary
 
       - name: Get the version (Release prep)
-        if: startsWith(github.ref, 'refs/tags/')
         id: get_version
         run: |
           version=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
@@ -94,22 +104,59 @@ jobs:
         shell: bash
 
       - name: Generate miners checksums (Release prep)
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
-             $fileName = git rev-parse --short HEAD
-             $hash = Get-FileHash -Algorithm SHA256 "bin/gpu-miner.exe" | Select -ExpandProperty "Hash"
-             Write-Output $hash.ToLower()"alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe" | Out-File -FilePath "bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe.checksum"
-             mv "bin/gpu-miner.exe" "bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe"
-             $hash = Get-FileHash -Algorithm SHA256 "bin\gpu-miner_$fileName" | Select -ExpandProperty "Hash"
-             Write-Output $hash.ToLower()"alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux" | Out-File -FilePath "bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux.checksum"
-             mv "bin\gpu-miner_$fileName" "bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux"
-             dir bin
+             filename=$(git rev-parse --short HEAD)
+             mv "gpu-miner_$filename" "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux"
+             mv "gpu-miner_$filename.exe" "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe"
+             sha256sum "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux" > "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux.checksum"
+             sha256sum "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe" > "alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe.checksum"
+             ls -la
+             
       - name: Release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux
-            bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux.checksum
-            bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe
-            bin\alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe.checksum
+            alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux
+            alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-linux.checksum
+            alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe
+            alephium-${{ steps.get_version.outputs.VERSION }}-cuda-miner-windows.exe.checksum
+            
+  buildx_and_push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    if: ${{ needs.release.result == 'success' }}
+    needs: release
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+
+      - name: Get the version
+        id: get_version
+        run: |
+          version=$(git describe --tags --abbrev=0)
+          echo $version
+          echo ${version:1}
+          echo ::set-output name=VERSION::$version
+          echo ::set-output name=VERSION-NO-V::${version:1}
+        shell: bash
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and publish docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: RELEASE=${{ steps.get_version.outputs.VERSION-NO-V }}
+          platforms: linux/amd64
+          tags: |
+            docker.io/capito27/gpu-miner:${{ steps.get_version.outputs.VERSION }}
+            docker.io/capito27/gpu-miner:latest
+          push: true


### PR DESCRIPTION
Pretty self explanatory. 
When a tag is pushed, along with the normal release, a docker image release should also be pushed.
Be sure to set the required dockerhub secrets.

Sample execution : https://github.com/capito27/gpu-miner/actions/runs/1512712233
Resulting docker image : https://hub.docker.com/repository/docker/capito27/gpu-miner/tags?page=1&ordering=last_updated