### PR TITLE
Add windows run-miner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,21 @@ You could specify the miner api with `-a broker` parameters, GPU indexes with `-
 4. Build gpu-miner:
    1. Clone gpu-miner to local
 
-   ``` sh
+   ``` shell
    git clone https://github.com/alephium/gpu-miner.git
    ```
    2. Open a powershell window, and launch the build script:
 
-   ```sh
+   ```shell
    cd your-gpu-miner-dir
    .\build.ps1
    ```
+   Executable file will be generated in `your-gpu-miner-dir/bin/` directory.
 
-Executable file will be generated in `your-gpu-miner-dir/bin/` directory.
+5. Start the miner in a powershell window :
+  ```shell
+  .\run-miner.ps1
+  ```
 
 If you have any questions, please reach out to us on Discord.
 

--- a/run-miner.ps1
+++ b/run-miner.ps1
@@ -1,0 +1,63 @@
+﻿
+$API_HOST="127.0.0.1"
+# Hide progress bar
+$node=Invoke-RestMethod -Uri "http://$($API_HOST):12973/infos/self-clique" -Method GET -ErrorAction SilentlyContinue
+
+if ($node -eq $null) {
+	Write-Host "Your full node is not running"
+	Exit 1
+}
+
+if ( ( -Not [bool]($node.PSobject.Properties.name -match "synced")) -or $node.synced -ne "True"){
+	Write-Host "Your full node is not synced"
+	Exit 1
+}
+
+$addresses=$(Invoke-RestMethod -Uri "http://$($API_HOST):12973/miners/addresses" -Method GET -ErrorAction SilentlyContinue).addresses
+
+if ($addresses -eq $null) {
+    Write-Host "Miner addresses are not set"
+    Exit 1
+}
+
+$miner_pid=$null
+# Use try-finally to kill the miner automatically when the script stops (ctrl+c only)
+try{
+	while($true){
+		# if we don't have an associated PID, spawn the miner and wait 10 seconds to ensure it started mining properly
+		if ($miner_pid -eq $null){
+			$miner_pid = (Start-Process "$PSScriptRoot\bin\gpu-miner.exe" "-a $($API_HOST)" -PassThru).ID
+			Start-Sleep -Seconds 10
+		}
+		
+		# Check if the process died
+		if (-not (Get-Process -Id $miner_pid -ErrorAction SilentlyContinue)) {
+			Write-Host "Miner died, restarting it..."
+			$miner_pid=$null
+			continue
+		}
+		
+		# Check if GPU usage stalled (in some cases of error -4095, the process doesn't die, but GPU usage stops)
+		$gpu_usage=0
+		$usage_threshold=75 # Expect at least 75% gpu usage at all times
+		((Get-Counter "\GPU Engine(pid_$($miner_pid)*engtype_Copy)\Utilization Percentage").CounterSamples | where CookedValue).CookedValue |
+			foreach { $gpu_usage = 0 } { $gpu_usage += [math]::Round($_,2) }
+			
+		Write-Output "Process $($miner_pid) GPU Engine Usage $($gpu_usage)%"
+		
+		if ($gpu_usage -lt $usage_threshold -and $miner_pid -ne $null){
+			Write-Host "Miner stalled, restarting it"
+			Stop-Process -Id $miner_pid -ErrorAction SilentlyContinue
+			$miner_pid=$null
+			continue
+		}
+		# Sleep 10 seconds before trying again
+		Start-Sleep -Seconds 10
+	}
+}
+finally
+{
+	if ($miner_pid -ne $null) {
+		Stop-Process -Id $miner_pid -ErrorAction SilentlyContinue
+	}
+}

--- a/run-miner.ps1
+++ b/run-miner.ps1
@@ -1,6 +1,7 @@
 ﻿
 $API_HOST="127.0.0.1"
-# Hide progress bar
+
+
 $node=Invoke-RestMethod -Uri "http://$($API_HOST):12973/infos/self-clique" -Method GET -ErrorAction SilentlyContinue
 
 if ($node -eq $null) {


### PR DESCRIPTION
Created a powershell script with the same behaviour as the run-miner.sh bas script, which checks if a node is running, if it's synced and if the addresses are set.

When runing the miner, it will check every 10 seconds if the miner is still alive, and if the GPU usage didn't stall. 
I've had times where with error -4095, the mining stopped but the process didn't die, so if the GPU usage of the process goes to under 75%, the script will restart the miner.