### PR TITLE
Add vga name when output device number and its cores.

### DIFF
--- a/src/main.cu
+++ b/src/main.cu
@@ -360,7 +360,9 @@ int main(int argc, char **argv)
     LOG("GPU count: %d\n", gpu_count);
     for (int i = 0; i < gpu_count; i++)
     {
-        LOG("GPU #%d has #%d cores\n", i, get_device_cores(i));
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop, i);
+        LOG("GPU #%d - %s has #%d cores\n", i, prop.name, get_device_cores(i));
         use_device[i] = true;
     }
 


### PR DESCRIPTION
Hi, this PR is all about add device name to current displayed device's information

before:
```
2022-01-09 15:14:16 | GPU #0 has #1280 cores
```

after: 
```
2022-01-09 15:14:16 | GPU #0 - NVIDIA GeForce GTX 1060 6GB has #1280 cores
```