### PR TITLE
apt addition to get-miner.sh

### DIFF
--- a/get-miner.sh
+++ b/get-miner.sh
@@ -8,8 +8,8 @@ then
     exit 1
 fi
 
-echo "Installing build-essential, python3-pip and nvidia-cuda-toolkit"
-sudo apt install -y build-essential nvidia-cuda-toolkit cmake
+echo "Installing build-essential+git, python3-pip and nvidia-cuda-toolkit"
+sudo apt install -y build-essential nvidia-cuda-toolkit cmake git
 
 echo "Installing conan"
 temp_file=$(mktemp --suffix=.deb)


### PR DESCRIPTION
installation can halt because it is not trying to install git earlier in the script, when calling git later.
Added git to the initial apt install